### PR TITLE
Fix script to work with zsh

### DIFF
--- a/src/bash.command-not-found
+++ b/src/bash.command-not-found
@@ -1,5 +1,6 @@
 command_not_found_handle () {
-    local INSULTS=(
+    local INSULTS 
+        INSULTS=(
         "Boooo!"
         "Don't you know anything?"
         "RTFM!"


### PR DESCRIPTION
Fix the message **command_not_found_handle:1: unknown file attribute** when using insulter on zsh.