### PR TITLE
Compatibility for zsh

### DIFF
--- a/src/bash.command-not-found
+++ b/src/bash.command-not-found
@@ -1,4 +1,4 @@
-command_not_found_handle () {
+insulter () {
     local INSULTS
     INSULTS=(
         "Boooo!"
@@ -76,3 +76,16 @@ command_not_found_handle () {
     # Return the exit code normally returned on invalid command
     return 127
 }
+
+case "${SHELL}" in
+    */zsh)
+        command_not_found_handler() {
+            insulter
+        }
+        ;;
+    */bash)
+        command_not_found_handle() {
+            insulter
+        }
+        ;;
+esac


### PR DESCRIPTION
Unlike bash, zsh uses command_not_found_handler() instead of command_not_found_handle() function acording to the [documentation](http://zsh.sourceforge.net/Doc/Release/Command-Execution.html#index-command_005fnot_005ffound_005fhandler).
So I addded some functionality to the script to use the correct function depending on the shell variable.