### PR TITLE
date and shuf removed, selection renamed

### DIFF
--- a/src/bash.command-not-found
+++ b/src/bash.command-not-found
@@ -1,6 +1,8 @@
 print_message () {
+
     local messages
-    local selection
+    local selectedMessage
+    local printOrNot
 
     messages=(
         "Boooo!"
@@ -73,10 +75,11 @@ print_message () {
 
     # Only print the message some of the time. RANDOM must be seeded to ensure it returns
     # different values on each iteration.
-    RANDOM=$(date +"%N")
-    selection=$((${RANDOM}%2))
-    if [[ ${selection} -lt 1 ]]; then
-        printf "\n  $(tput bold)$(tput setaf 1)$(shuf -n 1 -e "${messages[@]}")$(tput sgr0)\n\n"
+    RANDOM=$(od -vAn -N4 -tu < /dev/urandom)
+    printOrNot=$((${RANDOM}%2))
+    if [[ ${printOrNot} -lt 1 ]]; then
+        selectedMessage=${messages[$RANDOM % ${#messages[@]}]}
+        printf "\n  $(tput bold)$(tput setaf 1)$selectedMessage$(tput sgr0)\n\n"
     fi
 }
 


### PR DESCRIPTION
Removed date and shuf to make it compatible with macos:
- 'date +"%N"' has been replaced with ''od -vAn -N4 -tu < /dev/urandom' [1]
- 'shuf' with the new variable 'selectedMessage=${messages[$RANDOM % ${#messages[@]}]}'
- 'selection' has been renamed into 'printOrNot' (I found it confusing with the selected message)

[1] http://www.mactricksandtips.com/2012/01/generate-random-numbers-in-terminalbash.html